### PR TITLE
Update code to support Wagtail 2.0

### DIFF
--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -1,8 +1,14 @@
 from django.db import models
 from wagtail.contrib.settings.models import register_setting
-from wagtail.wagtailadmin.edit_handlers import FieldPanel
-from wagtail.wagtailcore.models import Page
-from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
+
+try:
+    from wagtail.admin.edit_handlers import FieldPanel
+    from wagtail.core.models import Page
+    from wagtail.images.edit_handlers import ImageChooserPanel
+except ImportError:  # fallback for Wagtail <2.0
+    from wagtail.wagtailadmin.edit_handlers import FieldPanel
+    from wagtail.wagtailcore.models import Page
+    from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 
 from wagtailschemaorg.models import BaseLDSetting, PageLDMixin
 from wagtailschemaorg.registry import register_site_thing

--- a/tests/app/urls.py
+++ b/tests/app/urls.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import django
 from django.conf import settings
-from django.conf.urls import url, include
+from django.conf.urls import include, url
 from django.contrib import admin
 
 try:

--- a/tests/app/urls.py
+++ b/tests/app/urls.py
@@ -1,15 +1,31 @@
 from __future__ import absolute_import, unicode_literals
 
+import django
 from django.conf import settings
-from django.conf.urls import include, url
+from django.conf.urls import url, include
 from django.contrib import admin
-from wagtail.wagtailadmin import urls as wagtailadmin_urls
-from wagtail.wagtailcore import urls as wagtail_urls
-from wagtail.wagtaildocs import urls as wagtaildocs_urls
 
-urlpatterns = [
-    url(r'^django-admin/', include(admin.site.urls)),
+try:
+    from wagtail.admin import urls as wagtailadmin_urls
+    from wagtail.core import urls as wagtail_urls
+    from wagtail.documents import urls as wagtaildocs_urls
+except ImportError:  # fallback for Wagtail <2.0
+    from wagtail.wagtailadmin import urls as wagtailadmin_urls
+    from wagtail.wagtailcore import urls as wagtail_urls
+    from wagtail.wagtaildocs import urls as wagtaildocs_urls
 
+
+# Include admin URLs correctly based on django version
+if django.VERSION[0] > 1 or (django.VERSION[0] == 1 and django.VERSION[1] >= 9):
+    urlpatterns = [
+        url(r'^django-admin/', admin.site.urls),
+    ]
+else:
+    urlpatterns = [
+        url(r'^django-admin/', include(admin.site.urls)),
+    ]
+
+urlpatterns += [
     url(r'^admin/', include(wagtailadmin_urls)),
     url(r'^documents/', include(wagtaildocs_urls)),
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -5,7 +5,6 @@ TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 BASE_DIR = os.path.dirname(TESTS_DIR)
 
 
-
 INSTALLED_APPS = [
     'tests.app',
     'wagtailschemaorg',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,22 +1,37 @@
 import os
+import wagtail
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 BASE_DIR = os.path.dirname(TESTS_DIR)
 
 
+
 INSTALLED_APPS = [
     'tests.app',
-
     'wagtailschemaorg',
+]
 
-    'wagtail.wagtailusers',
-    'wagtail.wagtaildocs',
-    'wagtail.wagtailimages',
-    'wagtail.wagtailsearch',
-    'wagtail.wagtailadmin',
-    'wagtail.wagtailcore',
+if wagtail.VERSION[0] > 1:
+    INSTALLED_APPS += [
+        'wagtail.users',
+        'wagtail.documents',
+        'wagtail.images',
+        'wagtail.search',
+        'wagtail.admin',
+        'wagtail.core',
+    ]
+else:
+    INSTALLED_APPS += [
+        'wagtail.wagtailusers',
+        'wagtail.wagtaildocs',
+        'wagtail.wagtailimages',
+        'wagtail.wagtailsearch',
+        'wagtail.wagtailadmin',
+        'wagtail.wagtailcore',
+    ]
+
+INSTALLED_APPS += [
     'wagtail.contrib.settings',
-
     'modelcluster',
     'taggit',
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -3,9 +3,14 @@ import json
 import os
 
 from django.test import TestCase
-from wagtail.wagtailcore.models import Site
-from wagtail.wagtailimages.models import Image
-from wagtail.wagtailimages.tests.utils import get_test_image_file
+try:
+    from wagtail.core.models import Site
+    from wagtail.images.models import Image
+    from wagtail.images.tests.utils import get_test_image_file
+except ImportError:  # fallback for Wagtail <2.0
+    from wagtail.wagtailcore.models import Site
+    from wagtail.wagtailimages.models import Image
+    from wagtail.wagtailimages.tests.utils import get_test_image_file
 
 from tests.app.models import PersonPage
 from wagtailschemaorg.encoder import JSONLDEncoder

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -3,9 +3,15 @@ import json
 
 from django.template import engines
 from django.test import RequestFactory, TestCase
-from wagtail.wagtailcore.models import Site
-from wagtail.wagtailimages.models import Image
-from wagtail.wagtailimages.tests.utils import get_test_image_file
+
+try:
+    from wagtail.core.models import Site
+    from wagtail.images.models import Image
+    from wagtail.images.tests.utils import get_test_image_file
+except ImportError:  # fallback for Wagtail <2.0
+    from wagtail.wagtailcore.models import Site
+    from wagtail.wagtailimages.models import Image
+    from wagtail.wagtailimages.tests.utils import get_test_image_file
 
 from tests.app.models import PersonPage, TestOrganisation
 from wagtailschemaorg import templates

--- a/wagtailschemaorg/encoder.py
+++ b/wagtailschemaorg/encoder.py
@@ -1,6 +1,9 @@
 from json import JSONEncoder
 
-from wagtail.wagtailimages.models import Image
+try:
+    from wagtail.images.models import Image
+except ImportError:  # fallback for Wagtail <2.0
+    from wagtail.wagtailimages.models import Image
 
 from .jsonld import ThingLD
 from .utils import image_ld


### PR DESCRIPTION
This PR fixes module paths that were changed in Wagtail 2.0. I also updated the tests to work with versions of Django greater than 1.9.